### PR TITLE
Moved `HomeController.Index` action and view to `Search` and added new `Index` view if feature flag enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Additional configuration may also be included in `appSettings.config` to manage 
   <add key="DeprecationInformation:Enabled" value="true" />
   <add key="DeprecationInformation:Title" value="Schools financial benchmarking will no longer be updated with new data" />
   <add key="DeprecationInformation:Body" value="Find the latest data on the new [Financial Benchmarking and Insights Tool](https://financial-benchmarking-and-insights-tool.education.gov.uk/){.govuk-notification-banner__link}.\nThis will include 2023-24 data for maintained schools.\n\nThis service will include all previous financial data available too." />
+  <add key="DeprecationInformation:NewServiceUrl" value="https://financial-benchmarking-and-insights-tool.education.gov.uk/" />
+  <add key="DeprecationInformation:OldServiceLinkText" value="Continue to schools financial benchmarking (legacy service)" />
 </appSettings>
 ```
 

--- a/Web/SFB.Web.UI.UnitTests/SchoolSearchControllerUnitTests.cs
+++ b/Web/SFB.Web.UI.UnitTests/SchoolSearchControllerUnitTests.cs
@@ -282,7 +282,7 @@ namespace SFB.Web.UI.UnitTests
 
 
         [Test]
-        public async Task SearchActionReturnsHomeViewIfNotValid()
+        public async Task SearchActionReturnsHomeSearchViewIfNotValid()
         {
             var controller = new SchoolSearchController(_mockLaService.Object, _mockLaSearchService.Object, _mockLocationSearchService.Object,
                 _mockFilterBuilder.Object, _valService, _mockContextDataService.Object, _mockSchoolSearchService.Object, 
@@ -293,7 +293,7 @@ namespace SFB.Web.UI.UnitTests
             var result = await controller.Search("" , SearchTypes.SEARCH_BY_NAME_ID, null, null, null, null, null, false, null, 0);
 
             Assert.IsNotNull(result);
-            Assert.AreEqual("../home/index", (result as ViewResult).ViewName);            
+            Assert.AreEqual("../home/search", (result as ViewResult).ViewName);            
         }
 
         [Test]

--- a/Web/SFB.Web.UI/Controllers/HomeController.cs
+++ b/Web/SFB.Web.UI/Controllers/HomeController.cs
@@ -24,11 +24,20 @@ namespace SFB.Web.UI.Controllers
 
         public ActionResult Index()
         {
-            var vm = new SearchViewModel(_benchmarkBasketService.GetSchoolBenchmarkList(), null)
+            return _showDeprecationInformation
+                ? View(nameof(Index), GetDeprecationViewModel())
+                : View(nameof(Search), GetSearchViewModel());
+        }
+
+        [Route("Search")]
+        public ActionResult Search()
+        {
+            if (_showDeprecationInformation)
             {
-                Authorities = _laService.GetLocalAuthorities()
-            };
-            return View(vm);
+                return View(GetSearchViewModel());
+            }
+            
+            return RedirectToAction("Index");
         }
 
         public ActionResult News()
@@ -45,14 +54,29 @@ namespace SFB.Web.UI.Controllers
 
             if (Request.Url?.PathAndQuery != "/")
             {
-                return PartialView("Partials/Headers/Deprecation", new DeprecationViewModel
-                {
-                    Title = ConfigurationManager.AppSettings["DeprecationInformation:Title"] ?? string.Empty,
-                    Body = (ConfigurationManager.AppSettings["DeprecationInformation:Body"] ?? string.Empty).Replace(@"\n", Environment.NewLine)
-                });
+                return PartialView("Partials/Headers/Deprecation", GetDeprecationViewModel());
             }
 
             return new EmptyResult();
+        }
+
+        private SearchViewModel GetSearchViewModel()
+        {
+            return new SearchViewModel(_benchmarkBasketService.GetSchoolBenchmarkList(), null)
+            {
+                Authorities = _laService.GetLocalAuthorities()
+            };
+        }
+        
+        private DeprecationViewModel GetDeprecationViewModel()
+        {
+            return new DeprecationViewModel
+            {
+                Title = ConfigurationManager.AppSettings["DeprecationInformation:Title"] ?? string.Empty,
+                Body = (ConfigurationManager.AppSettings["DeprecationInformation:Body"] ?? string.Empty).Replace(@"\n", Environment.NewLine),
+                NewServiceUrl = ConfigurationManager.AppSettings["DeprecationInformation:NewServiceUrl"] ?? string.Empty,
+                OldServiceLinkText = ConfigurationManager.AppSettings["DeprecationInformation:OldServiceLinkText"] ?? string.Empty
+            };
         }
     }
 }

--- a/Web/SFB.Web.UI/Controllers/TrustSearchController.cs
+++ b/Web/SFB.Web.UI/Controllers/TrustSearchController.cs
@@ -10,10 +10,10 @@ using SFB.Web.UI.Helpers.Constants;
 using SFB.Web.UI.Models;
 using SFB.Web.UI.Services;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Mvc;
-using System.Web.Routing;
 using SFB.Web.ApplicationCore.Helpers.Constants;
 using SFB.Web.ApplicationCore.Helpers.Enums;
 using SFB.Web.ApplicationCore.Services.LocalAuthorities;
@@ -28,6 +28,7 @@ namespace SFB.Web.UI.Controllers
         private readonly ILocationSearchService _locationSearchService;
         private readonly IValidationService _valService;
         private readonly IContextDataService _contextDataService;
+        private readonly bool _showDeprecationInformation;
 
         public TrustSearchController(ILocalAuthoritiesService laService,
             ILaSearchService laSearchService, ILocationSearchService locationSearchService, IFilterBuilder filterBuilder,
@@ -42,6 +43,7 @@ namespace SFB.Web.UI.Controllers
             _locationSearchService = locationSearchService;
             _valService = valService;
             _contextDataService = contextDataService;
+            _showDeprecationInformation = bool.TryParse(ConfigurationManager.AppSettings["DeprecationInformation:Enabled"], out var show) && show;
         }
 
         public async Task<ActionResult> Search(
@@ -58,6 +60,11 @@ namespace SFB.Web.UI.Controllers
         string tab = "list",
         string referrer = "home/index")
         {
+            if (_showDeprecationInformation)
+            {
+                referrer = "home/search";
+            }
+            
             string errorMessage = string.Empty;
             ViewBag.tab = tab;
             ViewBag.SearchMethod = "MAT";
@@ -322,6 +329,11 @@ namespace SFB.Web.UI.Controllers
                 Authorities = _laService.GetLocalAuthorities()
             };
 
+            if (referrer == "home/index")
+            {
+                referrer = "home/search";
+            }
+            
             return View("../" + referrer, searchVM);
         }
 

--- a/Web/SFB.Web.UI/Models/DeprecationViewModel.cs
+++ b/Web/SFB.Web.UI/Models/DeprecationViewModel.cs
@@ -1,10 +1,10 @@
-﻿using System.Configuration;
-using Microsoft.AspNet.Identity;
-namespace SFB.Web.UI.Models
+﻿namespace SFB.Web.UI.Models
 {
     public class DeprecationViewModel
     {
         public string Title { get; set; }
         public string Body { get; set; }
+        public string NewServiceUrl { get; set; }
+        public string OldServiceLinkText { get; set; }
     }
 }

--- a/Web/SFB.Web.UI/SFB.Web.UI.csproj
+++ b/Web/SFB.Web.UI/SFB.Web.UI.csproj
@@ -723,6 +723,7 @@
     <Content Include="public\vendorScripts\pptxgen.min.js" />
     <Content Include="robots.txt" />
     <Content Include="tsconfig.json" />
+    <Content Include="Views\Home\Search.cshtml" />
     <Content Include="Views\Shared\Partials\Headers\Deprecation.cshtml" />
     <Content Include="Views\Shared\Partials\Headers\Help.cshtml" />
     <Content Include="Views\Shared\Partials\RelatedServices.cshtml" />

--- a/Web/SFB.Web.UI/Views/Home/Index.cshtml
+++ b/Web/SFB.Web.UI/Views/Home/Index.cshtml
@@ -1,120 +1,32 @@
-﻿@using SFB.Web.UI.Helpers
-@model SFB.Web.UI.Models.SearchViewModel
-
+﻿@using Markdig
+@model SFB.Web.UI.Models.DeprecationViewModel
 @{
-    ViewBag.ErrorPrefix = Model.HasError() ? "Error: " : "";
-    ViewBag.pageClass = "schools-search-page";
-    ViewBag.pageDescription =
-    "Compare your school's income and expenditure with other schools in England. View your school's financial data, see how similar schools manage their finances, and use the information to establish relationships with other schools.";
-
-    ViewBag.HasMigratedJs = true;
+    var title = string.IsNullOrWhiteSpace(Model.Title) ? "Schools financial benchmarking will no longer be updated with new data" : Model.Title;
+    var body = string.IsNullOrWhiteSpace(Model.Body) ? string.Empty : Model.Body;
+    var newServiceUrl = string.IsNullOrWhiteSpace(Model.NewServiceUrl) ? "#" : Model.NewServiceUrl;
+    var oldServiceLinkText = string.IsNullOrWhiteSpace(Model.OldServiceLinkText) ? "Continue to schools financial benchmarking (legacy service)" : Model.OldServiceLinkText;
+    var pipeline = new MarkdownPipelineBuilder()
+        .UseGenericAttributes()
+        .Build();
 }
-
-@section BMListBannerContent
-{
-    @Html.Partial("Partials/BenchmarkListBanner")
-}
-
-
-<div class="govuk-grid-column-three-quarters govuk-!-padding-bottom-7">
-    <div id="govuk-error-summary-placeholder">
-        @if (!string.IsNullOrEmpty(Model.ErrorMessage))
-        {
-            <div class="govuk-error-summary" role="alert" aria-labelledby="ErrorSummaryHeading">
-                <h2 id="ErrorSummaryHeading" class="govuk-error-summary__title">
-                    There is a problem
-                </h2>
-                <div class="govuk-error-summary__body">
-                    <ul class="govuk-list govuk-error-summary__list">
-                        <li>
-                            <a class="govuk-link" href="#finderSection">@Model.ErrorMessage</a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-        }
+<div class="govuk-width-container" id="deprecation-notification">
+    <div class="govuk-!-margin-top-6">
+        <h2 class="govuk-heading-m">
+            @title
+        </h2>
+        <div class="govuk-body">
+            @Html.Raw(Markdown.ToHtml(body, pipeline))
+        </div>
     </div>
-
-    <h1 class="govuk-heading-xl page-heading">
-        Schools financial benchmarking
-    </h1>
-
-    <p class="govuk-body-l">Compare a school or trust&apos;s income and expenditure with similar establishments in England.</p>
-    <p class="govuk-body-m">You can view your school or academy trust's financial data, see how it compares with others and use the information to establish relationships with other schools or multi-academy trusts.</p>
-
-    @if (Model.ComparisonList.HomeSchoolUrn != null)
-    {
-        <div class="home-school-section">
-            <p class="govuk-body govuk-!-font-size-19">
-                @if (Model.ComparisonList.HomeSchoolType == "Federation")
-                {
-                    <span class="govuk-heading-s govuk-!-font-weight-bold govuk-!-display-inline">
-                        Your federation:
-                    </span>
-                }
-                else
-                {
-                    <span class="govuk-!-font-weight-bold">
-                        Your school:
-                    </span>
-                }
-                <a class="govuk-link govuk-!-font-weight-bold" href="/school?urn=@Model.ComparisonList.HomeSchoolUrn">@Model.ComparisonList.HomeSchoolName</a>
-            </p>
-        </div>
-    }
-
-    <div class="finder-section mt-1" id="finderSection">
-        <div id="SearchTypesAccordion" class="govuk-tabs" data-module="govuk-tabs">
-            <ul class="govuk-tabs__list">
-                <li class="govuk-tabs__list-item app-govuk-tabs__list-item--s hide-in-print" id="SchoolTab">
-                    <a href="#school-tab-panel"
-                       class="govuk-tabs__tab">Find a school</a>
-                </li>
-                <li class="govuk-tabs__list-item app-govuk-tabs__list-item--s hide-in-print" id="TrustTab">
-                    <a href="#trust-tab-panel"
-                       class="govuk-tabs__tab">Find an academy trust</a>
-                </li>
-                <li class="govuk-tabs__list-item app-govuk-tabs__list-item--s hide-in-print" id="NoDefaultTab">
-                    <a href="#no-default-tab-panel"
-                       class="govuk-tabs__tab">Compare with no default school</a>
-                </li>
-            </ul>
-            @Html.Partial("Partials/Search/SchoolTab")
-            @Html.Partial("Partials/Search/TrustTab")
-            @Html.Partial("Partials/Search/NoDefaultTab")
-        </div>
+    <div class="govuk-!-margin-top-5">
+        <a href="@newServiceUrl" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+            Go to new service
+            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+                <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+            </svg>
+        </a>
+    </div>
+    <div class="govuk-!-margin-top-7">
+        @Html.ActionLink(oldServiceLinkText, "Search", new RouteValueDictionary(), new Dictionary<string, object>{{ "class", "govuk-link" }})
     </div>
 </div>
-
-
-@section Aside {
-    <div class="govuk-grid-column-one-quarter aside">
-        <div class="app-related-items">
-            <h2 class="govuk-heading-m" id="subsection-title">Guidance</h2>
-            <nav role="navigation" aria-labelledby="subsection-title">
-                <ul class="govuk-list govuk-!-font-size-16">
-                    <li>
-                        <a class="govuk-link" href="Help/SadGuidance">Self-assessment dashboard guidance</a>
-                    </li>
-                    <li>
-                        <a class="govuk-link" href="Help/DataSources">Data Sources and Interpretation</a>
-                    </li>
-                    <li>
-                        <a class="govuk-link" href="~/Help/DataQueries">Do you have a school or trust data query?</a>
-                    </li>
-                    <li>
-                        <a class="govuk-link" href="~/Home/News">News</a>
-                    </li>
-                </ul>
-            </nav>
-        </div>
-    </div>
-
-}
-
-@section ViewScripts {
-    <script>
-        var localAuthorities = @Html.Raw(Model.Authorities);
-    </script>
-    <script src="@Html.Raw(Html.GetWebpackScriptUrl("SearchForm.*.js"))"></script>
-}

--- a/Web/SFB.Web.UI/Views/Home/Search.cshtml
+++ b/Web/SFB.Web.UI/Views/Home/Search.cshtml
@@ -1,0 +1,120 @@
+﻿@using SFB.Web.UI.Helpers
+@model SFB.Web.UI.Models.SearchViewModel
+
+@{
+    ViewBag.ErrorPrefix = Model.HasError() ? "Error: " : "";
+    ViewBag.pageClass = "schools-search-page";
+    ViewBag.pageDescription =
+    "Compare your school's income and expenditure with other schools in England. View your school's financial data, see how similar schools manage their finances, and use the information to establish relationships with other schools.";
+
+    ViewBag.HasMigratedJs = true;
+}
+
+@section BMListBannerContent
+{
+    @Html.Partial("Partials/BenchmarkListBanner")
+}
+
+
+<div class="govuk-grid-column-three-quarters govuk-!-padding-bottom-7">
+    <div id="govuk-error-summary-placeholder">
+        @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+        {
+            <div class="govuk-error-summary" role="alert" aria-labelledby="ErrorSummaryHeading">
+                <h2 id="ErrorSummaryHeading" class="govuk-error-summary__title">
+                    There is a problem
+                </h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                        <li>
+                            <a class="govuk-link" href="#finderSection">@Model.ErrorMessage</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        }
+    </div>
+
+    <h1 class="govuk-heading-xl page-heading">
+        Schools financial benchmarking
+    </h1>
+
+    <p class="govuk-body-l">Compare a school or trust&apos;s income and expenditure with similar establishments in England.</p>
+    <p class="govuk-body-m">You can view your school or academy trust's financial data, see how it compares with others and use the information to establish relationships with other schools or multi-academy trusts.</p>
+
+    @if (Model.ComparisonList.HomeSchoolUrn != null)
+    {
+        <div class="home-school-section">
+            <p class="govuk-body govuk-!-font-size-19">
+                @if (Model.ComparisonList.HomeSchoolType == "Federation")
+                {
+                    <span class="govuk-heading-s govuk-!-font-weight-bold govuk-!-display-inline">
+                        Your federation:
+                    </span>
+                }
+                else
+                {
+                    <span class="govuk-!-font-weight-bold">
+                        Your school:
+                    </span>
+                }
+                <a class="govuk-link govuk-!-font-weight-bold" href="/school?urn=@Model.ComparisonList.HomeSchoolUrn">@Model.ComparisonList.HomeSchoolName</a>
+            </p>
+        </div>
+    }
+
+    <div class="finder-section mt-1" id="finderSection">
+        <div id="SearchTypesAccordion" class="govuk-tabs" data-module="govuk-tabs">
+            <ul class="govuk-tabs__list">
+                <li class="govuk-tabs__list-item app-govuk-tabs__list-item--s hide-in-print" id="SchoolTab">
+                    <a href="#school-tab-panel"
+                       class="govuk-tabs__tab">Find a school</a>
+                </li>
+                <li class="govuk-tabs__list-item app-govuk-tabs__list-item--s hide-in-print" id="TrustTab">
+                    <a href="#trust-tab-panel"
+                       class="govuk-tabs__tab">Find an academy trust</a>
+                </li>
+                <li class="govuk-tabs__list-item app-govuk-tabs__list-item--s hide-in-print" id="NoDefaultTab">
+                    <a href="#no-default-tab-panel"
+                       class="govuk-tabs__tab">Compare with no default school</a>
+                </li>
+            </ul>
+            @Html.Partial("Partials/Search/SchoolTab")
+            @Html.Partial("Partials/Search/TrustTab")
+            @Html.Partial("Partials/Search/NoDefaultTab")
+        </div>
+    </div>
+</div>
+
+
+@section Aside {
+    <div class="govuk-grid-column-one-quarter aside">
+        <div class="app-related-items">
+            <h2 class="govuk-heading-m" id="subsection-title">Guidance</h2>
+            <nav role="navigation" aria-labelledby="subsection-title">
+                <ul class="govuk-list govuk-!-font-size-16">
+                    <li>
+                        <a class="govuk-link" href="Help/SadGuidance">Self-assessment dashboard guidance</a>
+                    </li>
+                    <li>
+                        <a class="govuk-link" href="Help/DataSources">Data Sources and Interpretation</a>
+                    </li>
+                    <li>
+                        <a class="govuk-link" href="~/Help/DataQueries">Do you have a school or trust data query?</a>
+                    </li>
+                    <li>
+                        <a class="govuk-link" href="~/Home/News">News</a>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+
+}
+
+@section ViewScripts {
+    <script>
+        var localAuthorities = @Html.Raw(Model.Authorities);
+    </script>
+    <script src="@Html.Raw(Html.GetWebpackScriptUrl("SearchForm.*.js"))"></script>
+}


### PR DESCRIPTION
[AB#233598](https://dfe-ssp.visualstudio.com/s198-DfE-Benchmarking-service/_workitems/edit/233598) [AB#231018](https://dfe-ssp.visualstudio.com/s198-DfE-Benchmarking-service/_workitems/edit/231018)

School and Trust search controllers also updated to resolve referrer logic on 'single' establishment match or missing search criteria scenarios.